### PR TITLE
fix: repair issue with misnamed db columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ yarn-error.log
 build
 pnpm-debug.log
 .env*
+packages/generator/README.md

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,19 +20,20 @@
       "internalConsoleOptions": "neverOpen"
     },
     {
-      "type": "pwa-node",
+      "name": "Debug Plugin",
+      "type": "node",
       "request": "launch",
-      "name": "Launch Program",
-      "skipFiles": [
-        "<node_internals>/**"
-      ],
       "args": [
-        "--brk-inspect"
+        "${workspaceRoot}/packages/generator/src/bin.ts"
       ],
-      "program": "${workspaceFolder}\\packages\\generator\\src\\generator.ts",
-      "outFiles": [
-        "${workspaceFolder}/**/*.js"
-      ]
+      "runtimeArgs": [
+        "--nolazy",
+        "-r",
+        "ts-node/register"
+      ],
+      "sourceMaps": true,
+      "cwd": "${workspaceRoot}/packages/generator",
+      "protocol": "inspector",
     }
   ]
 }

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -20,8 +20,8 @@
     "copy-templates:win32": "xcopy src\\templates dist\\templates /i /y",
     "copy-templates:default": "cp -rf src/templates dist/templates",
     "copy-readme": "run-script-os",
-    "copy-readme:win32": "copy ..\\..\\README.md dist\\README.md",
-    "copy-readme:default": "cp ../../README.md dist/README.md"
+    "copy-readme:win32": "copy ..\\..\\README.md README.md",
+    "copy-readme:default": "cp ../../README.md README.md"
   },
   "dependencies": {
     "@prisma/client": "3.7.0",
@@ -42,6 +42,7 @@
     "run-script-os": "^1.1.6",
     "semantic-release": "^18.0.1",
     "ts-jest": "27.1.2",
+    "ts-node": "^10.5.0",
     "typescript": "4.5.2"
   },
   "homepage": "https://github.com/iiian/prisma-generator-entityframework#readme",

--- a/packages/generator/src/__tests__/__fixtures__/getSampleDMMF.ts
+++ b/packages/generator/src/__tests__/__fixtures__/getSampleDMMF.ts
@@ -1,10 +1,14 @@
 import { getDMMF, getSchemaSync } from '@prisma/sdk';
 import path from 'path';
 
-const samplePrismaSchema = getSchemaSync(path.join(__dirname, './sample.prisma'));
+const sample_prisma_schema_path = path.join(__dirname, './sample.prisma');
+const sample_prisma_schema = getSchemaSync(sample_prisma_schema_path);
 
 export const getSampleDMMF = async () => {
-  return getDMMF({
-    datamodel: samplePrismaSchema,
-  });
-}
+  return {
+    dmmf: await getDMMF({
+      datamodel: sample_prisma_schema,
+    }),
+    sample_prisma_schema_path
+  };
+};

--- a/packages/generator/src/__tests__/__snapshots__/generateAll.ts.snap
+++ b/packages/generator/src/__tests__/__snapshots__/generateAll.ts.snap
@@ -59,11 +59,11 @@ namespace ProcessingFramework {
     [Column(\\"content\\")]
     public  string content { get; set; }
     [Required]
-    [Column(\\"createdAt\\")]
+    [Column(\\"created_at\\")]
     public DateTime createdAt { get; set; }
     [Required]
     [ForeignKey(\\"createdBy\\")]
-    [Column(\\"creatorId\\")]
+    [Column(\\"creator_id\\")]
     public int creatorId { get; set; }
     public User createdBy { get; set; }
     public Comment[] comment { get; set; }
@@ -87,11 +87,11 @@ namespace ProcessingFramework {
     public User creator { get; set; }
     [Required]
     [ForeignKey(\\"post\\")]
-    [Column(\\"postId\\")]
+    [Column(\\"post_id\\")]
     public int postId { get; set; }
     [Required]
     [ForeignKey(\\"creator\\")]
-    [Column(\\"creatorId\\")]
+    [Column(\\"creator_id\\")]
     public int creatorId { get; set; }
   }
 }",

--- a/packages/generator/src/__tests__/__snapshots__/generateModel.ts.snap
+++ b/packages/generator/src/__tests__/__snapshots__/generateModel.ts.snap
@@ -37,11 +37,11 @@ namespace ProcessingFramework {
     [Column(\\"content\\")]
     public  string content { get; set; }
     [Required]
-    [Column(\\"createdAt\\")]
+    [Column(\\"created_at\\")]
     public DateTime createdAt { get; set; }
     [Required]
     [ForeignKey(\\"createdBy\\")]
-    [Column(\\"creatorId\\")]
+    [Column(\\"creator_id\\")]
     public int creatorId { get; set; }
     public User createdBy { get; set; }
     public Comment[] comment { get; set; }
@@ -62,11 +62,11 @@ namespace ProcessingFramework {
     public User creator { get; set; }
     [Required]
     [ForeignKey(\\"post\\")]
-    [Column(\\"postId\\")]
+    [Column(\\"post_id\\")]
     public int postId { get; set; }
     [Required]
     [ForeignKey(\\"creator\\")]
-    [Column(\\"creatorId\\")]
+    [Column(\\"creator_id\\")]
     public int creatorId { get; set; }
   }
 }",

--- a/packages/generator/src/__tests__/generateAll.ts
+++ b/packages/generator/src/__tests__/generateAll.ts
@@ -3,12 +3,13 @@ import { getSampleDMMF } from './__fixtures__/getSampleDMMF';
 
 describe('generateAll', () => {
   it('should invoke generateModel for each model', async () => {
-    const sampleDMMF = await getSampleDMMF();
+    const { dmmf: sampleDMMF, sample_prisma_schema_path } = await getSampleDMMF();
 
     expect(generateAll({
       clientClassName: 'ExampleClient',
       namespace: 'ProcessingFramework',
       dbHost: 'Npgsql',
+      schema_file_path: sample_prisma_schema_path,
       connectionString: 'Host=my_postgres_host.com;Database=initial_db;Username=user;Password=password;',
       datamodel: sampleDMMF.datamodel,
     })).toMatchSnapshot();

--- a/packages/generator/src/__tests__/generateDbContext.ts
+++ b/packages/generator/src/__tests__/generateDbContext.ts
@@ -3,7 +3,7 @@ import { generateDbContext, GenerateDbContextParams } from '../helpers/generateD
 
 describe('generateDbContext', () => {
   it('should generate the source text for a client', async () => {
-    const sampleDMMF = await getSampleDMMF();
+    const { dmmf: sampleDMMF } = await getSampleDMMF();
     const args: GenerateDbContextParams = {
       clientClassName: 'Data',
       connectionString: '<CONNECTION-STRING-GOES-HERE>',

--- a/packages/generator/src/__tests__/generateModel.ts
+++ b/packages/generator/src/__tests__/generateModel.ts
@@ -1,17 +1,21 @@
-import { generateModel } from '../helpers/generateModel';
+import { generateModel, GenerateModelParams } from '../helpers/generateModel';
 import { getSampleDMMF } from './__fixtures__/getSampleDMMF';
 
 describe('generateModel', () => {
   it('should generate the source text for a model', async () => {
-    const sampleDMMF = await getSampleDMMF();
+    const { dmmf: sampleDMMF, sample_prisma_schema_path } = await getSampleDMMF();
     const models = sampleDMMF.datamodel.models.map(model => {
-      const args = {
-        clientClassName: 'Data',
+      const args: GenerateModelParams = {
         namespace: 'ProcessingFramework',
+        schema_file_path: sample_prisma_schema_path,
         model
       };
       return generateModel(args);
     });
     expect(models).toMatchSnapshot();
+    const post_model = models.find(model => model.includes("public class Post"));
+    const shouldContainAnnotation =
+      post_model!.search(/\[Column\(\"creator_id\"\)\]\s+public int creatorId \{ get\; set\; \}/);
+    expect(shouldContainAnnotation).not.toBe(-1);
   });
 }); 

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -34,6 +34,7 @@ generatorHandler({
       namespace,
       connectionString: getConnectionString(options.datasources?.[0]),
       dbHost: getDbHost(options.datasources?.[0]),
+      schema_file_path: options.schemaPath,
       datamodel: options.dmmf.datamodel
     });
     logger.info(`Compiled.`);

--- a/packages/generator/src/helpers/generateAll.ts
+++ b/packages/generator/src/helpers/generateAll.ts
@@ -19,6 +19,7 @@ export type GenerateAllParams = {
   connectionString: string;
   dbHost: string;
   datamodel: DMMF.Datamodel;
+  schema_file_path: string;
 };
 
 export function generateAll(params: GenerateAllParams): GenerateAllResult {
@@ -34,6 +35,7 @@ export function generateAll(params: GenerateAllParams): GenerateAllResult {
     name: `${model.name}.cs`,
     text: generateModel({
       namespace: params.namespace,
+      schema_file_path: params.schema_file_path,
       model,
     })
   }));

--- a/packages/generator/src/templates/Model.cs.hbs
+++ b/packages/generator/src/templates/Model.cs.hbs
@@ -16,7 +16,7 @@ namespace {{namespace}} {
     {{#isForeignKey . ../model/fields}}
     [ForeignKey("{{getForeignKey .. ../../model/fields}}")]
     {{/isForeignKey}}
-    [Column("{{name}}")]
+    [Column("{{getDbField name ../model.name ../raw_schema_lines}}")]
     {{/unless}}
     public {{getCSType .}} {{name}} { get; set; }
     {{/each}}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,7 @@ importers:
       run-script-os: ^1.1.6
       semantic-release: ^18.0.1
       ts-jest: 27.1.2
+      ts-node: ^10.5.0
       typescript: 4.5.2
     dependencies:
       '@prisma/client': 3.7.0_prisma@3.7.0
@@ -44,11 +45,12 @@ importers:
       '@types/jest': 27.0.3
       '@types/node': 17.0.0
       '@types/prettier': 2.4.2
-      jest: 27.4.3
+      jest: 27.4.3_ts-node@10.5.0
       prisma: 3.7.0
       run-script-os: 1.1.6
       semantic-release: 18.0.1
       ts-jest: 27.1.2_d967a5c71b36617f9eaef12c091f7695
+      ts-node: 10.5.0_760235798415d4af52b4f124075d6750
       typescript: 4.5.2
 
   packages/usage:
@@ -594,7 +596,7 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /@jest/core/27.5.1:
+  /@jest/core/27.5.1_ts-node@10.5.0:
     resolution: {integrity: sha512-AK6/UTrvQD0Cd24NSqmIA6rKsu0tKIxfiCducZvqxYdmMisOYAsdItspT+fQDQYARPf8XgjAFZi0ogW2agH5nQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     peerDependencies:
@@ -615,7 +617,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.9
       jest-changed-files: 27.5.1
-      jest-config: 27.5.1
+      jest-config: 27.5.1_ts-node@10.5.0
       jest-haste-map: 27.5.1
       jest-message-util: 27.5.1
       jest-regex-util: 27.5.1
@@ -2875,7 +2877,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli/27.5.1:
+  /jest-cli/27.5.1_ts-node@10.5.0:
     resolution: {integrity: sha512-Hc6HOOwYq4/74/c62dEE3r5elx8wjYqxY0r0G/nFrLDPMFRu6RA/u8qINOIkvhxG7mMQ5EJsOGfRpI8L6eFUVw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -2885,14 +2887,14 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 27.5.1
+      '@jest/core': 27.5.1_ts-node@10.5.0
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.9
       import-local: 3.1.0
-      jest-config: 27.5.1
+      jest-config: 27.5.1_ts-node@10.5.0
       jest-util: 27.5.1
       jest-validate: 27.5.1
       prompts: 2.4.2
@@ -2905,7 +2907,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jest-config/27.5.1:
+  /jest-config/27.5.1_ts-node@10.5.0:
     resolution: {integrity: sha512-5sAsjm6tGdsVbW9ahcChPAFCk4IlkQUknH5AvKjuLTSlcO/wCZKyFdn7Rg0EkC+OGgWODEy2hDpWB1PgzH0JNA==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     peerDependencies:
@@ -2938,6 +2940,7 @@ packages:
       pretty-format: 27.5.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
+      ts-node: 10.5.0_760235798415d4af52b4f124075d6750
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -3284,7 +3287,7 @@ packages:
       supports-color: 8.1.1
     dev: true
 
-  /jest/27.4.3:
+  /jest/27.4.3_ts-node@10.5.0:
     resolution: {integrity: sha512-jwsfVABBzuN3Atm+6h6vIEpTs9+VApODLt4dk2qv1WMOpb1weI1IIZfuwpMiWZ62qvWj78MvdvMHIYdUfqrFaA==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -3294,9 +3297,9 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 27.5.1
+      '@jest/core': 27.5.1_ts-node@10.5.0
       import-local: 3.1.0
-      jest-cli: 27.5.1
+      jest-cli: 27.5.1_ts-node@10.5.0
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -4715,7 +4718,7 @@ packages:
       '@types/jest': 27.0.3
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 27.4.3
+      jest: 27.4.3_ts-node@10.5.0
       jest-util: 27.5.1
       json5: 2.2.0
       lodash.memoize: 4.1.2
@@ -4752,6 +4755,37 @@ packages:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 4.5.5
+      v8-compile-cache-lib: 3.0.0
+      yn: 3.1.1
+    dev: true
+
+  /ts-node/10.5.0_760235798415d4af52b4f124075d6750:
+    resolution: {integrity: sha512-6kEJKwVxAJ35W4akuiysfKwKmjkbYxwQMTBaAxo9KKAx/Yd26mPUyhGz3ji+EsJoAgrLqVsYHNuuYwQe22lbtw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.7.0
+      '@tsconfig/node10': 1.0.8
+      '@tsconfig/node12': 1.0.9
+      '@tsconfig/node14': 1.0.1
+      '@tsconfig/node16': 1.0.2
+      '@types/node': 17.0.0
+      acorn: 8.7.0
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 4.5.2
       v8-compile-cache-lib: 3.0.0
       yn: 3.1.1
     dev: true


### PR DESCRIPTION
When constructing the initial release's tests, I failed to recognize
that `[Column]` annotations were being generated with references to the
client interface's name for a given field, rather than the db name
mapping. For example, if we had some field

```prisma
creatorId Int @map("creator_id")
```

then the plugin would generate the annotation

```C#
[Column("creatorId")]
```

This fix will repair the system to instead generate

```C#
[Column("creator_id")]
```