### PR TITLE
fix: repair support for sqlserver with sql auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,9 @@ Right now, the primary target is .NET core, version 5.0 and later. If ~~enough~~
 | postgres          | ✔️        | [Npgsql.EntityFrameworkCore.PostgreSQL](https://www.nuget.org/packages/Npgsql.EntityFrameworkCore.PostgreSQL/)     |
 | mysql             | ✔️        | [Pomelo.EntityFrameworkCore.MySql](https://www.nuget.org/packages/Pomelo.EntityFrameworkCore.MySql/)               |
 | sqlite            | ✔️        | [Microsoft.EntityFrameworkCore.Sqlite](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Sqlite/)       |
-| sqlserver         | ✔️ *      | [Microsoft.EntityFrameworkCore.SqlServer](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.SqlServer/) |
+| sqlserver         | ✔️        | [Microsoft.EntityFrameworkCore.SqlServer](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.SqlServer/) |
 | cockroachdb       | ❌        | -                                                                                                                  |
 | mongodb           | ❌        | -                                                                                                                  |
-
-> _* The prisma sql server connection string is [quite configurable](https://www.prisma.io/docs/concepts/database-connectors/sql-server#connection-details). For the time being, I've only verified the client connection strings with integrated security._
 
 For more information on EntityFramework database provider support, visit the [DbContext configuration guide](https://docs.microsoft.com/en-us/ef/core/dbcontext-configuration/).
 

--- a/packages/generator/src/__tests__/__snapshots__/getConnectionString.ts.snap
+++ b/packages/generator/src/__tests__/__snapshots__/getConnectionString.ts.snap
@@ -8,6 +8,8 @@ exports[`getConnectionString given a postgresql database connector should transf
 
 exports[`getConnectionString given a sqlite3 database connector should transform the connection string 1`] = `"Data Source=./test.db;"`;
 
-exports[`getConnectionString given a sqlserver database connector should transform the connection string 1`] = `"Host=host:5432;Database=initial_db;Username=user;Password=password;Encrypt=true;"`;
+exports[`getConnectionString given a sqlserver database connector should transform the connection string 1`] = `"Server=host:5432;Database=initial_db;User=user;Password=password;Encrypt=true;"`;
+
+exports[`getConnectionString given a sqlserver database connector should transform the connection string 2`] = `"Server=host:5432;Database=initial_db;User=user;Password=DANGER_PLAINTEXT;Encrypt=false;Trust Server Certificate=true"`;
 
 exports[`getConnectionString given a sqlserver database connector, with integrated security should transform the connection string 1`] = `"Server=localhost;Database=master;Integrated Security=true;"`;

--- a/packages/generator/src/__tests__/getConnectionString.ts
+++ b/packages/generator/src/__tests__/getConnectionString.ts
@@ -76,6 +76,21 @@ describe('getConnectionString', () => {
       expect(connection_string).toMatchSnapshot();
     });
   });
+  describe('given a sqlserver database connector', () => {
+    it('should transform the connection string', () => {
+      const connection_string = getConnectionString({
+        activeProvider: 'sqlserver',
+        config: {},
+        name: '',
+        provider: 'sqlserver',
+        url: {
+          fromEnvVar: null,
+          value: 'sqlserver://host:5432;Database=initial_db;user=user;PASSWORD=DANGER_PLAINTEXT;encrypt=false;trustServerCertificate=true'
+        }
+      });
+      expect(connection_string).toMatchSnapshot();
+    });
+  });
   describe('given a sqlserver database connector, with integrated security', () => {
     it('should transform the connection string', () => {
       const connection_string = getConnectionString({

--- a/packages/generator/src/helpers/getSqlServerConnectionString.ts
+++ b/packages/generator/src/helpers/getSqlServerConnectionString.ts
@@ -15,23 +15,25 @@ export function getSqlServerConnectionString(datasource: DataSource): string {
   let conn_str;
   if (config.hasOwnProperty('integratedsecurity')) {
     const db = config.initialcatalog ?? config.database;
-    const trust_cert = config.trustedcertificate;
+    const trustservercertificate = config.trustservercertificate ?? config.trustedcertificate;
 
     conn_str = `Server=${config.host};`;
     conn_str += (db && `Database=${db};`) || '';
     conn_str += `Integrated Security=${config.integratedsecurity};`;
-    conn_str += (trust_cert && `Trust Server Certificate=${trust_cert};`) || '';
+    conn_str += (trustservercertificate && `Trust Server Certificate=${trustservercertificate};`) || '';
   } else {
     const db = config.initialcatalog ?? config.database;
     const user = config.user ?? config.username;
     const pass = config.pass ?? config.password;
     const encrypt = config.encrypt ?? config.encrypted;
+    const trustservercertificate = config.trustservercertificate ?? config.trustedcertificate;
 
-    conn_str = `Host=${config.host};`;
+    conn_str = `Server=${config.host};`;
     conn_str += (db && `Database=${db};`) || '';
-    conn_str += (user && `Username=${user};`) || '';
+    conn_str += (user && `User=${user};`) || '';
     conn_str += (pass && `Password=${pass};`) || '';
     conn_str += (encrypt && `Encrypt=${encrypt};`) || '';
+    conn_str += (trustservercertificate && `Trust Server Certificate=${trustservercertificate}`) || '';
   }
   return conn_str;
   // const host_fmt: RegExp = /^sqlserver:\/\/(?<host>.*)(\:(?<port>\d{4,5}))?\;(database|Database|DATABASE)\=(?<initial_db>.*)\;(user|User|USER)\=(?<user>.*)\;(password|Password|PASSWORD)\=(?<password>.*)\;(encrypt|Encrypt|ENCRYPT)\=(?<encrypted>(true|false))(\;)?$/;

--- a/packages/usage/__scripts/run-mysql-tests.ps1
+++ b/packages/usage/__scripts/run-mysql-tests.ps1
@@ -1,0 +1,12 @@
+docker run --name mysql -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -e MYSQL_DATABASE=master -p 3306:3306 -d mysql:latest
+DO {
+  start-sleep -s 1;
+  mysql --user=root --execute='show DATABASES;' > $null;
+} UNTIL ($LASTEXITCODE -eq 0)
+npm run migrate-mysql-tests
+cd csharp-integration-tests\unit-tests
+dotnet restore
+dotnet test --filter unit_tests.MysqlTests
+cd ..\..
+docker stop mysql
+docker rm mysql

--- a/packages/usage/__scripts/run-postgres-tests.ps1
+++ b/packages/usage/__scripts/run-postgres-tests.ps1
@@ -1,0 +1,12 @@
+docker run --name postgres -e POSTGRES_PASSWORD=password -e POSTGRES_USER=postgres -e POSTGRES_DB=postgres -p 5432:5432 -d postgres:latest
+DO {
+  start-sleep -s 1;
+  psql -c 'SELECT 1;' postgresql://postgres:password@localhost:5432/postgres > $null;
+} UNTIL ($LASTEXITCODE -eq 0)
+npm run migrate-postgres-tests
+cd csharp-integration-tests\unit-tests
+dotnet restore
+dotnet test --filter unit_tests.PostgresTests
+cd ..\..
+docker stop postgres
+docker rm postgres

--- a/packages/usage/__scripts/run-sqlite-tests.ps1
+++ b/packages/usage/__scripts/run-sqlite-tests.ps1
@@ -1,0 +1,5 @@
+npm run migrate-sqlite-tests
+cd csharp-integration-tests\unit-tests
+dotnet restore
+dotnet test --filter unit_tests.SqliteTests
+cd ..\..

--- a/packages/usage/__scripts/run-sqlserver-tests.ps1
+++ b/packages/usage/__scripts/run-sqlserver-tests.ps1
@@ -1,0 +1,9 @@
+docker run --name sqlserver -e MSSQL_PID=Developer -e ACCEPT_EULA=Y -e SA_PASSWORD=iStH1sGooDeNouGhMicroSoFt -p 1433:1433 -d mcr.microsoft.com/mssql/server:2019-latest
+start-sleep -s 10;
+npm run migrate-sqlserver-tests
+cd csharp-integration-tests\unit-tests
+dotnet restore
+dotnet test --filter unit_tests.SqlServerTests
+cd ..\..
+docker stop sqlserver
+docker rm sqlserver

--- a/packages/usage/__scripts/run-tests.ps1
+++ b/packages/usage/__scripts/run-tests.ps1
@@ -1,0 +1,7 @@
+.\__scripts\run-mysql-tests.ps1;
+
+.\__scripts\run-postgres-tests.ps1;
+
+.\__scripts\run-sqlite-tests.ps1;
+
+.\__scripts\run-sqlserver-tests.ps1;

--- a/packages/usage/package.json
+++ b/packages/usage/package.json
@@ -5,6 +5,9 @@
   "main": "src/app.js",
   "license": "MIT",
   "scripts": {
+    "integration-tests": "run-script-os",
+    "integration-tests:windows": ".\\__scripts\\run-tests.ps1",
+    "integration-tests:default": "echo TODO",
     "migrate-tests": "npm run migrate-mysql-tests && npm run migrate-postgres-tests && npm run migrate-sqlserver-tests && npm run migrate-sqlite-tests",
     "migrate-mysql-tests": "npx prisma migrate dev --schema=mysql/schema.prisma --name=mysql-init",
     "migrate-postgres-tests": "npx prisma migrate dev --schema=postgres/schema.prisma --name=postgres-init",

--- a/packages/usage/sqlserver/schema.prisma
+++ b/packages/usage/sqlserver/schema.prisma
@@ -7,7 +7,9 @@ generator cs {
 
 datasource db {
   provider = "sqlserver"
-  url      = "sqlserver://localhost;initialCatalog=master;integratedSecurity=true;trustServerCertificate=true;"
+  // to run on integrated security, use the following connection config:
+  // url      = "sqlserver://localhost;initialCatalog=master;integratedSecurity=true;trustServerCertificate=true;"
+  url      = "sqlserver://localhost;user=sa;password=iStH1sGooDeNouGhMicroSoFt;encrypt=false;trustServerCertificate=true;"
 }
 
 model User {


### PR DESCRIPTION
Sql authentication in sql server was based on some faulty assumptions about how connection strings are meant to be configured. A series of containerized test cases based on latest releases were built for postgres, mysql, and sqlserver. When testing sqlserver, it was discovered that `Host` was being used instead of `Server`, `Username` instead of `User`, and `Trust Server Certificate` was a missing option.